### PR TITLE
Changes to 'require'

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -19,9 +19,9 @@ end
 
 class App < Sinatra::Base
   register Mustache::Sinatra
-  require './views/layout'
+  require 'views/layout'
 
-  set :mustache, { :views => './views/', :templates => './templates/' }
+  set :mustache, { :views => 'views/', :templates => 'templates/' }
   set :method_override, true
 
   configure do

--- a/app.rb
+++ b/app.rb
@@ -19,9 +19,9 @@ end
 
 class App < Sinatra::Base
   register Mustache::Sinatra
-  require 'views/layout'
+  require './views/layout'
 
-  set :mustache, { :views => 'views/', :templates => 'templates/' }
+  set :mustache, { :views => './views/', :templates => './templates/' }
   set :method_override, true
 
   configure do

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), 'app'))
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '.'))
+require 'app'
 run App

--- a/config.ru
+++ b/config.ru
@@ -1,2 +1,2 @@
-require 'app'
+require File.expand_path(File.join(File.dirname(__FILE__), 'app'))
 run App

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,3 @@
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '.'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'app'
 run App


### PR DESCRIPTION
In ruby 1.9.2 the current directory is no longer part of the load path.  I found this out the hard way when trying to follow the blog post and the require statements would constantly fail.  Simply changing the statement to 'require './app'' works, however it replicates the same security problem that the change in 1.9.2 sough to avoid.  The solution I used in app.rb is more verbose, but more secure.  A few changes were necessary elsewhere to make sure the app could, for instance, find the views directory.  I've tested and the app now functions when running either 1.9.2 or 1.8.7.
